### PR TITLE
Command critical notification missing

### DIFF
--- a/core/class/mobile.class.php
+++ b/core/class/mobile.class.php
@@ -1017,6 +1017,12 @@ class mobile extends eqLogic
 				$cmd->setOrder($order);
 				$order++;
 			}
+			$cmd->setEqLogic_id($this->getId());
+			$cmd->setType('action');
+			$cmd->setSubType('message');
+			if ($cmd->getChanged() === true) $cmd->save();
+
+			// Commande notification Silencieuse
 			$cmd = $this->getCmd(null, 'notifSilent'); 
 			if (!is_object($cmd)) {
 				$cmd = new mobileCmd();


### PR DESCRIPTION
Bonjour,

La commande Notification Critique n'est pas créée sur un nouvel équipement car il manque un $cmd->save() mais c'est peut-être volontaire ?